### PR TITLE
Switch to new installer for compatibility with composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     }
   ],
   "require": {
-    "symfony/console": "^3.2",
-    "wireframe-framework/processwire-composer-installer": "^1.1"
+    "wireframe-framework/processwire-composer-installer": "^1.1",
+    "symfony/console": "^3.2"
   },
   "require-dev": {
     "lostkobrakai/conveyor": "^0.1.3"

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     }
   ],
   "require": {
-    "hari/pw-module": "~1.0",
-    "symfony/console": "^3.2"
+    "symfony/console": "^3.2",
+    "wireframe-framework/processwire-composer-installer": "^1.1"
   },
   "require-dev": {
     "lostkobrakai/conveyor": "^0.1.3"


### PR DESCRIPTION
There seems to be an issue with the original installer as noted here harikt/pwmoduleinstaller/issues/2.

Switching to this newer installer seems to fix the issue. I also have the impression that it is more actively supported? I have tested locally following [this setup. ](https://medium.com/pvtl/local-composer-package-development-47ac5c0e5bb4)

Thanks!